### PR TITLE
Fixup: Post Release Touchups to Serializer Code

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,7 @@ verify_ssl = true
 
 [dev-packages]
 pytest = "*"   # Test runner
+pytest-watch = "*"  # Automated re-running test suite on file save
 expects = "*"  # Allows from readable tests, expect(something).to(have(some_property))
 faker = "*"  # Allows for easier test by generating fake data.
 ipdb = "*"  # better debugger than pdb. import ipdb;ipdb.set_trace()

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "86c200331a8e046fb331ed860f07c4702f1ae55707deb4653b1e301bb2ce211e"
+            "sha256": "0636d0dd345afd950ee156c2f7748d356a796a46d0bbdd6f92671c8ed29b7421"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -112,13 +112,14 @@
         },
         "mysqlclient": {
             "hashes": [
-                "sha256:3f39855a4ad22805361e782cc4d1010ac74796225fa2d1c03cc16673ccdc983a",
-                "sha256:a6b5648f648b16335e3b1aaec93dc3fcc81a9a661180e306936437cc522c810b",
-                "sha256:edd42ccaa444b00702d5374b2f5f7585c9d0ce201917f15339f1c3cf91c1b1ed",
-                "sha256:fb2f75aea14722390d2d8ddf384ad99da708c707a96656210a7be8af20a2c5e5"
+                "sha256:3739824f4b8f29a6a4e5fc965f933fdce7c9edc2454990c3e5c6e038779e5580",
+                "sha256:4861e33b9fad83dadf38feae77a14106365fc8c354ec4300fab5d8ccfbee4b4e",
+                "sha256:4d91dde55230a512937aafc5981c6c11c0efad2c6b3d33e83287208c8bdab367",
+                "sha256:8944d9008c29abfa43e3c97551416ea23b2ccb017af85682b79f34fc26dc43ae",
+                "sha256:8df057b08fc27d8f7106bfa997d0a21e2acef017f905f06d6fb0aa6a20d4d2b2"
             ],
             "index": "pypi",
-            "version": "==2.0.1"
+            "version": "==2.0.2"
         },
         "six": {
             "hashes": [
@@ -204,12 +205,26 @@
             ],
             "version": "==0.2.0"
         },
+        "colorama": {
+            "hashes": [
+                "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b",
+                "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==0.4.4"
+        },
         "decorator": {
             "hashes": [
                 "sha256:41fa54c2a0cc4ba648be4fd43cff00aedf5b9465c9bf18d64325bc225f08f760",
                 "sha256:e3a62f0520172440ca0dcc823749319382e377f37f140a0b99ef45fecb84bfe7"
             ],
             "version": "==4.4.2"
+        },
+        "docopt": {
+            "hashes": [
+                "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"
+            ],
+            "version": "==0.6.2"
         },
         "expects": {
             "hashes": [
@@ -220,19 +235,19 @@
         },
         "faker": {
             "hashes": [
-                "sha256:5398268e1d751ffdb3ed36b8a790ed98659200599b368eec38a02eed15bce997",
-                "sha256:d4183b8f57316de3be27cd6c3b40e9f9343d27c95c96179f027316c58c2c239e"
+                "sha256:1fcb415562ee6e2395b041e85fa6901d4708d30b84d54015226fa754ed0822c3",
+                "sha256:e8beccb398ee9b8cc1a91d9295121d66512b6753b4846eb1e7370545d46b3311"
             ],
             "index": "pypi",
-            "version": "==4.17.1"
+            "version": "==5.0.1"
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:590690d61efdd716ff82c39ca9a9d4209252adfe288a4b5721181050acbd4175",
-                "sha256:d9b8a46a0885337627a6430db287176970fff18ad421becec1d64cfc763c2099"
+                "sha256:3314a7d37120371fd6b4eb91d46e28c062c5a9e113be14d2cc5620062f86e210",
+                "sha256:8f3c7e27824aa3283b384ee1f9238770e4fafe479150fa7012830dfae110e7d0"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==3.1.0"
+            "version": "==3.2.0"
         },
         "iniconfig": {
             "hashes": [
@@ -273,11 +288,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8",
-                "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"
+                "sha256:24e0da08660a87484d1602c30bb4902d74816b6985b93de36926f5bc95741858",
+                "sha256:78598185a7008a470d64526a8059de9aaa449238f280fc9eb6b13ba6c4109093"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==20.4"
+            "version": "==20.8"
         },
         "parso": {
             "hashes": [
@@ -327,19 +342,19 @@
         },
         "py": {
             "hashes": [
-                "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2",
-                "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"
+                "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3",
+                "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.9.0"
+            "version": "==1.10.0"
         },
         "pygments": {
             "hashes": [
-                "sha256:381985fcc551eb9d37c52088a32914e00517e57f4a21609f48141ba08e193fa0",
-                "sha256:88a0bbcd659fcb9573703957c6b9cff9fab7295e6e76db54c9d00ae42df32773"
+                "sha256:ccf3acacf3782cbed4a989426012f1c535c9a90d3a7fc3f16d231b9372d2b716",
+                "sha256:f275b6c0909e5dafd2d6269a656aa90fa58ebf4a74f8fcf9053195d226b24a08"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==2.7.2"
+            "version": "==2.7.3"
         },
         "pyparsing": {
             "hashes": [
@@ -351,11 +366,18 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:4288fed0d9153d9646bfcdf0c0428197dba1ecb27a33bb6e031d002fa88653fe",
-                "sha256:c0a7e94a8cdbc5422a51ccdad8e6f1024795939cc89159a0ae7f0b316ad3823e"
+                "sha256:b12e09409c5bdedc28d308469e156127004a436b41e9b44f9bff6446cbab9152",
+                "sha256:d69e1a80b34fe4d596c9142f35d9e523d98a2838976f1a68419a8f051b24cec6"
             ],
             "index": "pypi",
-            "version": "==6.1.2"
+            "version": "==6.2.0"
+        },
+        "pytest-watch": {
+            "hashes": [
+                "sha256:06136f03d5b361718b8d0d234042f7b2f203910d8568f63df2f866b547b3d4b9"
+            ],
+            "index": "pypi",
+            "version": "==4.2.0"
         },
         "python-dateutil": {
             "hashes": [
@@ -394,6 +416,22 @@
                 "sha256:d023ee369ddd2763310e4c3eae1ff649689440d4ae59d7485eb4cfbbe3e359f7"
             ],
             "version": "==4.3.3"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918",
+                "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c",
+                "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==3.7.4.3"
+        },
+        "watchdog": {
+            "hashes": [
+                "sha256:78ea5d78f2cf8e4d6343ab2cbed93bb47b7a85b1c2f90a1dea365226bbab68ac"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.0.1"
         },
         "wcwidth": {
             "hashes": [

--- a/app/api/counties_controller.py
+++ b/app/api/counties_controller.py
@@ -1,4 +1,5 @@
 from flask import jsonify
+from flask_login import current_user
 
 from app.models.counties import County
 from app.serializers.county_serializer import CountySerializer
@@ -6,5 +7,7 @@ from app.serializers.county_serializer import CountySerializer
 
 def get_county(id_):
     county = County.query.get(id_)
+    if county.id == current_user.county.id:
+        return jsonify(county=CountySerializer.call(county, view="full_view"))
 
-    return jsonify(county=CountySerializer.call(county, view="full_view"))
+    return jsonify(county=CountySerializer.call(county))

--- a/app/serializers/base_serializer.py
+++ b/app/serializers/base_serializer.py
@@ -1,21 +1,4 @@
-import re
-
-
-def camel_case(string):
-    """Convert a string to camelCase.
-
-    Args:
-        string - string to be converted to camel case.
-
-    Examples:
-        camel_case("Hello World") == "helloWorld"
-        camel_case("Hello,world") == "hello,World"
-        camel_case("Hello_world") == "helloWorld"
-        camel_case("hello_world.txt_includehelp-WEBSITE") == \
-            "helloWorld.TxtIncludehelpWebsite"
-    """
-    string = re.sub(r"(_|-)+", " ", string).title().replace(" ", "")
-    return string[0].lower() + string[1:]
+from app.utils.string_utils import camel_case
 
 
 class BaseSerializer:

--- a/app/utils/string_utils.py
+++ b/app/utils/string_utils.py
@@ -1,0 +1,18 @@
+import re
+
+
+def camel_case(string):
+    """Convert a string to camelCase.
+
+    Args:
+        string - string to be converted to camel case.
+
+    Examples:
+        camel_case("Hello World") == "helloWorld"
+        camel_case("Hello,world") == "hello,World"
+        camel_case("Hello_world") == "helloWorld"
+        camel_case("hello_world.txt_includehelp-WEBSITE") == \
+            "helloWorld.TxtIncludehelpWebsite"
+    """
+    string = re.sub(r"(_|-)+", " ", string).title().replace(" ", "")
+    return string[0].lower() + string[1:]

--- a/bin/dev
+++ b/bin/dev
@@ -23,7 +23,7 @@ boot () {
 }
 
 test () {
-   dc_cmd run --rm test pipenv run pytest -s tests/ "$@"
+   dc_cmd run --rm test pipenv run ptw -- -s tests/ "$@"
 }
 
 python () {

--- a/bin/dev
+++ b/bin/dev
@@ -27,7 +27,7 @@ bash () {
 }
 
 test () {
-   dc_cmd run --rm test pipenv run ptw -- -s tests/ "$@"
+   dc_cmd run --rm test pipenv run ptw --poll "$@"
 }
 
 python () {

--- a/bin/dev
+++ b/bin/dev
@@ -22,6 +22,10 @@ boot () {
   dc_cmd up -d "$@"
 }
 
+bash () {
+  dc_cmd exec app bash "$@"
+}
+
 test () {
    dc_cmd run --rm test pipenv run ptw -- -s tests/ "$@"
 }

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+log_cli = True
+addopts = --capture=no --last-failed --new-first
+testpaths =
+    tests

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,3 @@
 [pytest]
-log_cli = True
-addopts = --capture=no --last-failed --new-first
-testpaths =
-    tests
+addopts=--capture=no --last-failed --new-first
+testpaths=tests

--- a/tests/api/authentication_controller_test.py
+++ b/tests/api/authentication_controller_test.py
@@ -1,0 +1,20 @@
+from expects import expect, have_keys, equal
+
+
+class TestApiAuthenticationController:
+    def test_login(self, client):
+        data = client.post(
+            "/api/authentication/login",
+            json=dict(username="test_user"),
+            follow_redirects=True,
+        ).get_json()
+        expect(data["user"]).to(
+            have_keys({"countyId": 1, "id": 1, "username": "test_user"})
+        )
+
+    def test_logout(self, client):
+        data = client.post(
+            "/api/authentication/logout",
+            follow_redirects=True,
+        ).get_json()
+        expect(data["message"]).to(equal("Logout successful."))

--- a/tests/api/counties_controller_test.py
+++ b/tests/api/counties_controller_test.py
@@ -1,11 +1,17 @@
 from expects import expect, have_keys, contain
 
+from app.models.users import User
+
 
 class TestApiCountiesController:
-    def test_get_county(self, client):
-        """Start with a blank database."""
+    def test_get_county_for_currrent_user(self, client, login):
+        """Return the county view of the current user."""
 
-        data = client.get("/api/counties/1").get_json()
+        user = User.query.get(1)
+        county = user.county
+        login(user.username)
+
+        data = client.get(f"/api/counties/{county.id}").get_json()
 
         expect(data["county"]).to(
             have_keys(

--- a/tests/api/counties_controller_test.py
+++ b/tests/api/counties_controller_test.py
@@ -77,3 +77,26 @@ class TestApiCountiesController:
                 }
             )
         )
+
+    def test_get_county_for_other_user(self, client, login):
+        """Return the county view you get when viewing another user."""
+
+        user1 = User.query.get(1)
+        user2 = User.query.get(2)
+        county2 = user2.county
+        login(user1.username)
+
+        data = client.get(f"/api/counties/{county2.id}").get_json()
+
+        expect(data["county"]).to(
+            have_keys(
+                {
+                    "id": 2,
+                    "land": 150,
+                    "leader": "Mechazoid",
+                    "name": "Mechland",
+                    "race": "Human",
+                    "title": "Sir",
+                }
+            )
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,8 @@ import pytest
 
 from app.main import app
 
+asyncio_logger = logging.getLogger("asyncio")
+asyncio_logger.setLevel(logging.INFO)  # Silence useless asyncio debug messages.
 faker_logger = logging.getLogger("faker")
 faker_logger.setLevel(logging.INFO)  # Quiet faker locale messages down in tests.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import pytest
 from app.main import app
 
 asyncio_logger = logging.getLogger("asyncio")
-asyncio_logger.setLevel(logging.INFO)
+asyncio_logger.setLevel(logging.INFO)  # Silence useless asyncio debug messages.
 faker_logger = logging.getLogger("faker")
 faker_logger.setLevel(logging.INFO)  # Quiet faker locale messages down in tests.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,6 @@ import pytest
 
 from app.main import app
 
-asyncio_logger = logging.getLogger("asyncio")
-asyncio_logger.setLevel(logging.INFO)  # Silence useless asyncio debug messages.
 faker_logger = logging.getLogger("faker")
 faker_logger.setLevel(logging.INFO)  # Quiet faker locale messages down in tests.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,5 +12,18 @@ faker_logger.setLevel(logging.INFO)  # Quiet faker locale messages down in tests
 
 @pytest.fixture
 def client():
-    with app.test_client() as client:
-        yield client
+    with app.app_context():
+        with app.test_client() as client:
+            yield client
+
+
+@pytest.fixture
+def login(client):
+    def _login(username):
+        return client.post(
+            "/api/authentication/login",
+            json=dict(username=username),
+            follow_redirects=True,
+        ).get_json()
+
+    return _login

--- a/tests/serializers/base_serializer_test.py
+++ b/tests/serializers/base_serializer_test.py
@@ -1,6 +1,6 @@
 from expects import expect, have_keys, equal
 
-from app.serializers.base_serializer import BaseSerializer, camel_case
+from app.serializers.base_serializer import BaseSerializer
 
 
 class MockModel:
@@ -42,7 +42,7 @@ class TestBaseSerializer:
             equal([MockSerializer.call(mock_model) for mock_model in mock_models])
         )
 
-    def test_call_camel_case(self, faker):
+    def test_key_tranformer(self, faker):
         """Test that the serializer converts all field names to camel case.
 
         Args:
@@ -77,17 +77,6 @@ class TestBaseSerializer:
 
         expect(MockSerializer.call(mock_model)).to(
             have_keys(id=id_, username=username, fullname=f"{first_name} {last_name}")
-        )
-
-    def test_camel_case(self):
-        """Assert that the camel_case function converts strings to camelCase."""
-
-        assert camel_case("Hello World") == "helloWorld"
-        assert camel_case("Hello,world") == "hello,World"
-        assert camel_case("Hello_world") == "helloWorld"
-        assert (
-            camel_case("hello_world.txt_includehelp-WEBSITE")
-            == "helloWorld.TxtIncludehelpWebsite"
         )
 
     def test_view(self, faker):

--- a/tests/serializers/base_serializer_test.py
+++ b/tests/serializers/base_serializer_test.py
@@ -16,6 +16,11 @@ class MockModel:
 
 class TestBaseSerializer:
     def test_call(self, faker):
+        """Test most basic serialization call.
+
+        Can the serializer extract the listed fields from the model?
+        """
+
         class MockSerializer(BaseSerializer):
             def __init__(self, model):
                 super().__init__(model)
@@ -29,6 +34,12 @@ class TestBaseSerializer:
         expect(MockSerializer.call(mock_model)).to(have_keys(id=id_, username=username))
 
     def test_call_on_array_of_models(self, faker):
+        """Test that serializer works on arrays.
+
+        Does the serializer, when given an array, operate the same as the serializer
+        when looped over each element of the array.
+        """
+
         class MockSerializer(BaseSerializer):
             def __init__(self, model):
                 super().__init__(model)
@@ -61,6 +72,12 @@ class TestBaseSerializer:
         expect(MockSerializer.call(mock_model)).to(have_keys(firstName=first_name))
 
     def test_custom_fields(self, faker):
+        """Test that the serializer accepts custom methods.
+
+        When you supply a keyword argument with a method call, the serializer
+        adds that field and its results to the output.
+        """
+
         class MockSerializer(BaseSerializer):
             def __init__(self, model):
                 super().__init__(model)
@@ -80,6 +97,15 @@ class TestBaseSerializer:
         )
 
     def test_view(self, faker):
+        """Test that the serializer supports custom views.
+
+        You can specify alternate views for the serializer that add
+        additional fields to the output.
+
+        e.g You will want to return a more detailed view of the current user's County
+        than for the counties of other players.
+        """
+
         class MockSerializer(BaseSerializer):
             def __init__(self, model, view=None):
                 super().__init__(model, view=view)

--- a/tests/utils/string_utils_test.py
+++ b/tests/utils/string_utils_test.py
@@ -1,0 +1,16 @@
+from app.utils.string_utils import camel_case
+
+
+class TestStringUtils:
+    """Test the various helpfull string manipulation functions."""
+
+    def test_camel_case(self):
+        """Assert that the camel_case function converts strings to camelCase."""
+
+        assert camel_case("Hello World") == "helloWorld"
+        assert camel_case("Hello,world") == "hello,World"
+        assert camel_case("Hello_world") == "helloWorld"
+        assert (
+            camel_case("hello_world.txt_includehelp-WEBSITE")
+            == "helloWorld.TxtIncludehelpWebsite"
+        )


### PR DESCRIPTION
Make changes as requested in review of https://github.com/elthran/UDK/pull/30.

Add Pytest watching/auto-rerun test suite (my own request).
Move `camel_case` function to a `app/utils/string_utils`.
Add documentation comments to the BaseSerializer test suite.
Test the Authentication routes.
Allow testing of routes that require login.
Add different view for county when viewing as current_user, and add appropriate tests.